### PR TITLE
适配 dubbo 2.7.0, 并支持简化注册参数(dubbo.registry.simplified = true)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,36 +4,36 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>dubbo-registry</artifactId>
-        <groupId>com.alibaba</groupId>
-        <version>2.6.5</version>
+        <groupId>org.apache.dubbo</groupId>
+        <version>2.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.alibaba</groupId>
+    <groupId>org.apache.dubbo</groupId>
     <artifactId>dubbo-registry-nacos</artifactId>
-    <version>0.0.2</version>
+    <version>2.7.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Compiler settings properties -->
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <dubbo.version>2.6.5</dubbo.version>
-        <nacos.version>0.6.1</nacos.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <dubbo.version>2.7.0</dubbo.version>
+        <nacos.version>0.8.0</nacos.version>
     </properties>
 
     <dependencies>
 
         <dependency>
-            <groupId>com.alibaba</groupId>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-registry-api</artifactId>
             <version>${dubbo.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba</groupId>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-common</artifactId>
             <version>${dubbo.version}</version>
             <optional>true</optional>
@@ -48,35 +48,35 @@
 
         <!-- Test Libraries -->
         <dependency>
-            <groupId>com.alibaba</groupId>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-config-api</artifactId>
             <version>${dubbo.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba</groupId>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-serialization-hessian2</artifactId>
             <version>${dubbo.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba</groupId>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-config-spring</artifactId>
             <version>${dubbo.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba</groupId>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-rpc-dubbo</artifactId>
             <version>${dubbo.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba</groupId>
+            <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-remoting-netty</artifactId>
             <version>${dubbo.version}</version>
             <scope>test</scope>

--- a/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -415,6 +415,7 @@ public class NacosRegistry extends FailbackRegistry {
         String category = url.getParameter(Constants.CATEGORY_KEY, Constants.DEFAULT_CATEGORY);
         URL newURL = url.addParameter(Constants.CATEGORY_KEY, category);
         newURL = newURL.addParameter(Constants.PROTOCOL_KEY, url.getProtocol());
+        newURL = newURL.addParameter(Constants.INTERFACE_KEY, url.getServiceInterface());
         String ip = url.getHost();
         int port = url.getPort();
         Instance instance = new Instance();
@@ -431,14 +432,18 @@ public class NacosRegistry extends FailbackRegistry {
 
     private String getServiceName(URL url, String category) {
         StringBuilder serviceNameBuilder = new StringBuilder(category);
-        appendIfPresent(serviceNameBuilder, url, Constants.INTERFACE_KEY);
+        appendIfPresent(serviceNameBuilder, url, Constants.INTERFACE_KEY, url.getPath());
         appendIfPresent(serviceNameBuilder, url, Constants.VERSION_KEY);
         appendIfPresent(serviceNameBuilder, url, Constants.GROUP_KEY);
         return serviceNameBuilder.toString();
     }
 
     private void appendIfPresent(StringBuilder target, URL url, String parameterName) {
-        String parameterValue = url.getParameter(parameterName);
+        appendIfPresent(target, url, parameterName, null);
+    }
+
+    private void appendIfPresent(StringBuilder target, URL url, String parameterName, String defaultValue) {
+        String parameterValue = url.getParameter(parameterName, defaultValue);
         if (!StringUtils.isBlank(parameterValue)) {
             target.append(SERVICE_NAME_SEPARATOR).append(parameterValue);
         }

--- a/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
+++ b/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistry.java
@@ -14,14 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.dubbo.registry.nacos;
+package org.apache.dubbo.registry.nacos;
 
-import com.alibaba.dubbo.common.Constants;
-import com.alibaba.dubbo.common.URL;
-import com.alibaba.dubbo.common.utils.UrlUtils;
-import com.alibaba.dubbo.registry.NotifyListener;
-import com.alibaba.dubbo.registry.Registry;
-import com.alibaba.dubbo.registry.support.FailbackRegistry;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.listener.Event;
@@ -31,13 +25,20 @@ import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ListView;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.dubbo.common.Constants;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.UrlUtils;
+import org.apache.dubbo.registry.NotifyListener;
+import org.apache.dubbo.registry.Registry;
+import org.apache.dubbo.registry.support.FailbackRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.*;
 
-import static com.alibaba.dubbo.common.Constants.*;
+import static org.apache.dubbo.common.Constants.*;
+
 
 /**
  * Nacos {@link Registry}
@@ -125,7 +126,8 @@ public class NacosRegistry extends FailbackRegistry {
         return urls;
     }
 
-    protected void doRegister(URL url) {
+    @Override
+    public void doRegister(URL url) {
         final String serviceName = getServiceName(url);
         final Instance instance = createInstance(url);
         execute(new NamingServiceCallback() {
@@ -135,7 +137,8 @@ public class NacosRegistry extends FailbackRegistry {
         });
     }
 
-    protected void doUnregister(final URL url) {
+    @Override
+    public void doUnregister(final URL url) {
         execute(new NamingServiceCallback() {
             public void callback(NamingService namingService) throws NacosException {
                 String serviceName = getServiceName(url);
@@ -145,7 +148,8 @@ public class NacosRegistry extends FailbackRegistry {
         });
     }
 
-    protected void doSubscribe(final URL url, final NotifyListener listener) {
+    @Override
+    public void doSubscribe(final URL url, final NotifyListener listener) {
         List<String> serviceNames = getServiceNames(url, listener);
         doSubscribe(url, listener, serviceNames);
     }
@@ -164,7 +168,7 @@ public class NacosRegistry extends FailbackRegistry {
     }
 
     @Override
-    protected void doUnsubscribe(URL url, NotifyListener listener) {
+    public void doUnsubscribe(URL url, NotifyListener listener) {
         if (isAdminProtocol(url)) {
             shutdownServiceNamesLookup();
         }

--- a/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistryFactory.java
+++ b/src/main/java/org/apache/dubbo/registry/nacos/NacosRegistryFactory.java
@@ -14,30 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.dubbo.registry.nacos;
+package org.apache.dubbo.registry.nacos;
 
-import com.alibaba.dubbo.common.URL;
-import com.alibaba.dubbo.registry.Registry;
-import com.alibaba.dubbo.registry.RegistryFactory;
-import com.alibaba.dubbo.registry.support.AbstractRegistryFactory;
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.client.naming.utils.StringUtils;
-
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.registry.Registry;
+import org.apache.dubbo.registry.RegistryFactory;
+import org.apache.dubbo.registry.support.AbstractRegistryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 
-import static com.alibaba.dubbo.common.Constants.BACKUP_KEY;
-import static com.alibaba.nacos.api.PropertyKeyConst.ACCESS_KEY;
-import static com.alibaba.nacos.api.PropertyKeyConst.CLUSTER_NAME;
-import static com.alibaba.nacos.api.PropertyKeyConst.ENDPOINT;
-import static com.alibaba.nacos.api.PropertyKeyConst.NAMESPACE;
-import static com.alibaba.nacos.api.PropertyKeyConst.SECRET_KEY;
-import static com.alibaba.nacos.api.PropertyKeyConst.SERVER_ADDR;
+import static com.alibaba.nacos.api.PropertyKeyConst.*;
 import static com.alibaba.nacos.client.naming.utils.UtilAndComs.NACOS_NAMING_LOG_NAME;
+import static org.apache.dubbo.common.Constants.BACKUP_KEY;
 
 /**
  * Nacos {@link RegistryFactory}

--- a/src/main/resources/META-INF/dubbo/com.alibaba.dubbo.registry.RegistryFactory
+++ b/src/main/resources/META-INF/dubbo/com.alibaba.dubbo.registry.RegistryFactory
@@ -1,1 +1,0 @@
-nacos=com.alibaba.dubbo.registry.nacos.NacosRegistryFactory

--- a/src/main/resources/META-INF/dubbo/org.apache.dubbo.registry.RegistryFactory
+++ b/src/main/resources/META-INF/dubbo/org.apache.dubbo.registry.RegistryFactory
@@ -1,0 +1,1 @@
+nacos=org.apache.dubbo.registry.nacos.NacosRegistryFactory

--- a/src/test/java/org/apache/dubbo/demo/consumer/DemoServiceConsumerBootstrap.java
+++ b/src/test/java/org/apache/dubbo/demo/consumer/DemoServiceConsumerBootstrap.java
@@ -14,12 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.dubbo.demo.consumer;
+package org.apache.dubbo.demo.consumer;
 
-import com.alibaba.dubbo.config.annotation.Reference;
-import com.alibaba.dubbo.config.spring.context.annotation.EnableDubbo;
-import com.alibaba.dubbo.demo.service.DemoService;
-
+import org.apache.dubbo.config.annotation.Reference;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.apache.dubbo.demo.service.DemoService;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.PropertySource;
 

--- a/src/test/java/org/apache/dubbo/demo/consumer/DemoServiceConsumerXmlBootstrap.java
+++ b/src/test/java/org/apache/dubbo/demo/consumer/DemoServiceConsumerXmlBootstrap.java
@@ -14,28 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.dubbo.demo.provider;
+package org.apache.dubbo.demo.consumer;
 
-import com.alibaba.dubbo.config.spring.context.annotation.EnableDubbo;
-import com.alibaba.dubbo.demo.service.DemoService;
-
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.PropertySource;
+import org.apache.dubbo.demo.service.DemoService;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import java.io.IOException;
 
 /**
- * {@link DemoService} provider demo
+ * {@link DemoService} consumer demo XML bootstrap
  */
-@EnableDubbo(scanBasePackages = "com.alibaba.dubbo.demo.service")
-@PropertySource(value = "classpath:/provider-config.properties")
-public class DemoServiceProviderBootstrap {
+public class DemoServiceConsumerXmlBootstrap {
 
     public static void main(String[] args) throws IOException {
-        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-        context.register(DemoServiceProviderBootstrap.class);
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext();
+        context.setConfigLocation("/META-INF/spring/dubbo-consumer-context.xml");
         context.refresh();
-        System.out.println("DemoService provider is starting...");
+        System.out.println("DemoService consumer (XML) is starting...");
+        DemoService demoService = context.getBean("demoService", DemoService.class);
+        for (int i = 0; i < 10; i++) {
+            System.out.println(demoService.sayName("小马哥（mercyblitz）"));
+        }
         System.in.read();
+        context.close();
     }
 }

--- a/src/test/java/org/apache/dubbo/demo/provider/DemoServiceProviderBootstrap.java
+++ b/src/test/java/org/apache/dubbo/demo/provider/DemoServiceProviderBootstrap.java
@@ -14,24 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.dubbo.demo.provider;
+package org.apache.dubbo.demo.provider;
 
-import com.alibaba.dubbo.demo.service.DemoService;
-
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.apache.dubbo.demo.service.DemoService;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.PropertySource;
 
 import java.io.IOException;
 
 /**
- * {@link DemoService} provider demo XML bootstrap
+ * {@link DemoService} provider demo
  */
-public class DemoServiceProviderXmlBootstrap {
+@EnableDubbo(scanBasePackages = "com.alibaba.dubbo.demo.service")
+@PropertySource(value = "classpath:/provider-config.properties")
+public class DemoServiceProviderBootstrap {
 
     public static void main(String[] args) throws IOException {
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext();
-        context.setConfigLocation("/META-INF/spring/dubbo-provider-context.xml");
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.register(DemoServiceProviderBootstrap.class);
         context.refresh();
-        System.out.println("DemoService provider (XML) is starting...");
+        System.out.println("DemoService provider is starting...");
         System.in.read();
     }
 }

--- a/src/test/java/org/apache/dubbo/demo/provider/DemoServiceProviderXmlBootstrap.java
+++ b/src/test/java/org/apache/dubbo/demo/provider/DemoServiceProviderXmlBootstrap.java
@@ -14,29 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.dubbo.demo.consumer;
+package org.apache.dubbo.demo.provider;
 
-import com.alibaba.dubbo.demo.service.DemoService;
-
+import org.apache.dubbo.demo.service.DemoService;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import java.io.IOException;
 
 /**
- * {@link DemoService} consumer demo XML bootstrap
+ * {@link DemoService} provider demo XML bootstrap
  */
-public class DemoServiceConsumerXmlBootstrap {
+public class DemoServiceProviderXmlBootstrap {
 
     public static void main(String[] args) throws IOException {
         ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext();
-        context.setConfigLocation("/META-INF/spring/dubbo-consumer-context.xml");
+        context.setConfigLocation("/META-INF/spring/dubbo-provider-context.xml");
         context.refresh();
-        System.out.println("DemoService consumer (XML) is starting...");
-        DemoService demoService = context.getBean("demoService", DemoService.class);
-        for (int i = 0; i < 10; i++) {
-            System.out.println(demoService.sayName("小马哥（mercyblitz）"));
-        }
+        System.out.println("DemoService provider (XML) is starting...");
         System.in.read();
-        context.close();
     }
 }

--- a/src/test/java/org/apache/dubbo/demo/service/DefaultService.java
+++ b/src/test/java/org/apache/dubbo/demo/service/DefaultService.java
@@ -14,11 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.dubbo.demo.service;
+package org.apache.dubbo.demo.service;
 
-import com.alibaba.dubbo.config.annotation.Service;
-import com.alibaba.dubbo.rpc.RpcContext;
-
+import org.apache.dubbo.config.annotation.Service;
+import org.apache.dubbo.rpc.RpcContext;
 import org.springframework.beans.factory.annotation.Value;
 
 

--- a/src/test/java/org/apache/dubbo/demo/service/DemoService.java
+++ b/src/test/java/org/apache/dubbo/demo/service/DemoService.java
@@ -14,12 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.dubbo.registry.nacos;
+package org.apache.dubbo.demo.service;
 
 /**
- * {@link NacosRegistryFactory} Test
+ * DemoService
  *
  * @since 2.6.5
  */
-public class NacosRegistryFactoryTest {
+public interface DemoService {
+
+    String sayName(String name);
+
 }

--- a/src/test/java/org/apache/dubbo/registry/nacos/NacosRegistryFactoryTest.java
+++ b/src/test/java/org/apache/dubbo/registry/nacos/NacosRegistryFactoryTest.java
@@ -14,15 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.dubbo.demo.service;
+package org.apache.dubbo.registry.nacos;
 
 /**
- * DemoService
+ * {@link NacosRegistryFactory} Test
  *
  * @since 2.6.5
  */
-public interface DemoService {
-
-    String sayName(String name);
-
+public class NacosRegistryFactoryTest {
 }

--- a/src/test/java/org/apache/dubbo/registry/nacos/NacosRegistryTest.java
+++ b/src/test/java/org/apache/dubbo/registry/nacos/NacosRegistryTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.dubbo.registry.nacos;
+package org.apache.dubbo.registry.nacos;
 
 /**
  * {@link NacosRegistry} Test

--- a/src/test/resources/META-INF/spring/dubbo-consumer-context.xml
+++ b/src/test/resources/META-INF/spring/dubbo-consumer-context.xml
@@ -11,6 +11,6 @@
     <dubbo:registry address="nacos://127.0.0.1:8848"/>
 
     <!-- 引用服务接口 -->
-    <dubbo:reference id="demoService" interface="com.alibaba.dubbo.demo.service.DemoService" version="2.0.0"/>
+    <dubbo:reference id="demoService" interface="org.apache.dubbo.demo.service.DemoService" version="2.0.0"/>
 
 </beans>

--- a/src/test/resources/META-INF/spring/dubbo-provider-context.xml
+++ b/src/test/resources/META-INF/spring/dubbo-provider-context.xml
@@ -14,8 +14,8 @@
     <dubbo:protocol name="dubbo" port="-1"/>
 
     <!-- 声明需要暴露的服务接口 -->
-    <dubbo:service interface="com.alibaba.dubbo.demo.service.DemoService" ref="demoService" version="2.0.0"/>
+    <dubbo:service interface="org.apache.dubbo.demo.service.DemoService" ref="demoService" version="2.0.0"/>
 
     <!-- 和本地bean一样实现服务 -->
-    <bean id="demoService" class="com.alibaba.dubbo.demo.service.DefaultService"/>
+    <bean id="demoService" class="org.apache.dubbo.demo.service.DefaultService"/>
 </beans>


### PR DESCRIPTION
对于元数据中心, 还没来得及理解, 在我实际适配过程中发现 simplified = true 时, 会出现注册失败和订阅失败的情况, 加了自己理解的fix, 请大佬过目